### PR TITLE
WIP: Adds ability to set alternate local folder for config/metadata directory

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -5,6 +5,7 @@ import pydantic
 import tum_esm_utils
 import click
 import em27_metadata
+from typing import Union
 
 _RETRIEVAL_ENTRYPOINT = tum_esm_utils.files.rel_to_abs_path(
     "src", "retrieval", "main.py"
@@ -16,10 +17,10 @@ profiles_command_group = click.Group(name="profiles")
 export_command_group = click.Group(name="export")
 
 
-def _check_config_validity() -> None:
+def _check_config_validity(config_path: Union[str, None] = None) -> None:
     import src
     try:
-        src.types.Config.load()
+        src.types.Config.load(config_path)
         click.echo(click.style("Config is valid", fg="green", bold=True))
     except pydantic.ValidationError as e:
         click.echo(

--- a/cli.py
+++ b/cli.py
@@ -1,11 +1,11 @@
 import ftplib
 import io
+import os
 import sys
 import pydantic
 import tum_esm_utils
 import click
 import em27_metadata
-from typing import Union
 
 _RETRIEVAL_ENTRYPOINT = tum_esm_utils.files.rel_to_abs_path(
     "src", "retrieval", "main.py"
@@ -17,8 +17,15 @@ profiles_command_group = click.Group(name="profiles")
 export_command_group = click.Group(name="export")
 
 
-def _check_config_validity(config_path: Union[str, None] = None) -> None:
+def _check_config_validity() -> None:
     import src
+    from src.utils.files import read_yaml
+    config_setup = read_yaml(tum_esm_utils.files.rel_to_abs_path("./config_setup.yml"))
+    if config_setup['alternate_config_dir'] is None:
+        config_path = None # default config path
+    else:
+        config_path = os.path.join(config_setup["alternate_config_dir"], "config.json")
+    print("CONFIG PATH: ", config_path)
     try:
         src.types.Config.load(config_path)
         click.echo(click.style("Config is valid", fg="green", bold=True))

--- a/config_setup.template.yml
+++ b/config_setup.template.yml
@@ -1,0 +1,4 @@
+# alternate_config_dir value is the full path to your local folder containing the following metadata files:
+# config.json, sensors.json, locations.json, campaigns.json
+# leave blank for using default config folder location inside this repository or separate metadata repository 
+alternate_config_dir: 

--- a/pdm.lock
+++ b/pdm.lock
@@ -5,7 +5,7 @@
 groups = ["default", "dev"]
 strategy = ["inherit_metadata"]
 lock_version = "4.5.0"
-content_hash = "sha256:d915556097b820cf6313278dd95830d82af702704dd2d3bd355faf1ed2250976"
+content_hash = "sha256:5c9804fd5edefebb25d637165bd5b1d96b6c47cdd7b01032bd50237f5953db5e"
 
 [[metadata.targets]]
 requires_python = ">=3.10.0,<4.0.0"
@@ -1128,6 +1128,17 @@ dependencies = [
 files = [
     {file = "tum_esm_utils-2.2.1-py3-none-any.whl", hash = "sha256:a72b7c39c3f0f4115fa33eb5affd23ccaf020dbb40d6a488622b1194fd60aaac"},
     {file = "tum_esm_utils-2.2.1.tar.gz", hash = "sha256:a0f9981ee9d2821307fc4e146d542ee43a14bcfc45b5436ea6c754874bb9cf7c"},
+]
+
+[[package]]
+name = "types-pyyaml"
+version = "6.0.12.20240917"
+requires_python = ">=3.8"
+summary = "Typing stubs for PyYAML"
+groups = ["dev"]
+files = [
+    {file = "types-PyYAML-6.0.12.20240917.tar.gz", hash = "sha256:d1405a86f9576682234ef83bcb4e6fff7c9305c8b1fbad5e0bcd4f7dbdc9c587"},
+    {file = "types_PyYAML-6.0.12.20240917-py3-none-any.whl", hash = "sha256:392b267f1c0fe6022952462bf5d6523f31e37f6cea49b14cee7ad634b6301570"},
 ]
 
 [[package]]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,6 +54,7 @@ dev = [
     "tailwind-colors>=1.2.1",
     "pytest-order>=1.2.1",
     "yapf>=0.40.2",
+    "types-PyYAML>=6.0.12",
 ]
 
 [tool.pdm]

--- a/src/export/main.py
+++ b/src/export/main.py
@@ -9,10 +9,17 @@ import tum_esm_utils
 
 sys.path.append(tum_esm_utils.files.rel_to_abs_path("../.."))
 from src import types, utils, export
+from src.utils.files import read_yaml
 
 
 def run() -> None:
-    config = types.Config.load()
+    config_setup = read_yaml(tum_esm_utils.files.rel_to_abs_path("../../config_setup.yml"))
+    if config_setup['alternate_config_dir'] is None:
+        config_path = None # default config path
+    else:
+        config_path = os.path.join(config_setup["alternate_config_dir"], "config.json")
+    print("CONFIG PATH: ", config_path)
+    config = types.Config.load(config_path)
     assert config.export_targets is not None, "no export config found"
     assert len(config.export_targets) > 0, "no export targets found"
 

--- a/src/profiles/main.py
+++ b/src/profiles/main.py
@@ -2,13 +2,14 @@ import os
 import sys
 import tum_esm_utils
 import ftplib
+from typing import Union
 
 sys.path.append(tum_esm_utils.files.rel_to_abs_path("../.."))
 from src import types, profiles
 
 
-def run() -> None:
-    config = types.Config.load()
+def run(config_path: Union[str, None] = None) -> None:
+    config = types.Config.load(config_path)
     assert config.profiles is not None, "No profiles config found"
 
     for variant in ["GGG2014", "GGG2020"]:

--- a/src/profiles/main.py
+++ b/src/profiles/main.py
@@ -6,9 +6,16 @@ from typing import Union
 
 sys.path.append(tum_esm_utils.files.rel_to_abs_path("../.."))
 from src import types, profiles
+from src.utils.files import read_yaml
 
 
-def run(config_path: Union[str, None] = None) -> None:
+def run() -> None:
+    config_setup = read_yaml(tum_esm_utils.files.rel_to_abs_path("../../config_setup.yml"))
+    if config_setup['alternate_config_dir'] is None:
+        config_path = None # default config path
+    else:
+        config_path = os.path.join(config_setup["alternate_config_dir"], "config.json")
+    print("CONFIG PATH: ", config_path)
     config = types.Config.load(config_path)
     assert config.profiles is not None, "No profiles config found"
 

--- a/src/retrieval/main.py
+++ b/src/retrieval/main.py
@@ -10,6 +10,7 @@ import tum_esm_utils
 
 sys.path.append(tum_esm_utils.files.rel_to_abs_path("../.."))
 from src import types, utils, retrieval
+from src.utils.files import read_yaml
 
 
 def run() -> None:
@@ -18,8 +19,14 @@ def run() -> None:
     main_logger.info(f"Starting the automation with PID {os.getpid()}")
 
     # load config
+    config_setup = read_yaml(tum_esm_utils.files.rel_to_abs_path("../../config_setup.yml"))
+    if config_setup['alternate_config_dir'] is None:
+        config_path = None # default config path
+    else:
+        config_path = os.path.join(config_setup["alternate_config_dir"], "config.json")
+    print("CONFIG PATH: ", config_path)
     try:
-        config = types.Config.load()
+        config = types.Config.load(config_path)
         main_logger.info("Config is valid")
     except Exception as e:
         main_logger.exception(e, "Config file invalid")

--- a/src/retrieval/session/run_retrieval.py
+++ b/src/retrieval/session/run_retrieval.py
@@ -1,5 +1,6 @@
 import json
 import os
+import sys
 import tum_esm_utils
 from src import types
 
@@ -16,30 +17,15 @@ def run(session: types.RetrievalSession, test_mode: bool = False) -> None:
     if isinstance(session, types.Proffast1RetrievalSession):
         tum_esm_utils.shell.run_shell_command(
             " ".join([
-                os.path.join(
-                    _PROJECT_DIR,
-                    ".venv",
-                    "bin",
-                    "python",
-                ),
-                os.path.join(
-                    session.ctn.container_path,
-                    "prfpylot",
-                    "main.py",
-                ),
-                '"' + json.dumps(session.model_dump()).replace('"', '\\"') +
-                '"',
+                sys.executable,
+                os.path.join(session.ctn.container_path, "prfpylot", "main.py"),
+                '"' + json.dumps(session.model_dump()).replace('"', '\\"') + '"',
             ])
         )
     elif isinstance(session, types.Proffast2RetrievalSession):
         tum_esm_utils.shell.run_shell_command(
             " ".join([
-                os.path.join(
-                    _PROJECT_DIR,
-                    ".venv",
-                    "bin",
-                    "python",
-                ),
+                sys.executable,
                 os.path.join(
                     _PROJECT_DIR,
                     "src",

--- a/src/types/config.py
+++ b/src/types/config.py
@@ -1,5 +1,5 @@
 from __future__ import annotations
-from typing import Literal, Optional
+from typing import Literal, Optional, Union
 import datetime
 import tum_esm_utils
 import pydantic
@@ -322,14 +322,16 @@ class Config(pydantic.BaseModel):
 
     @staticmethod
     def load(
-        path: str = tum_esm_utils.files.
-        rel_to_abs_path("../../config/config.json"),
+        path: Union[str, None] = None,
         ignore_path_existence: bool = False,
     ) -> Config:
         """Load the config file from `config/config.json` (or any given path).
 
         If `check_path_existence` is set, it will check whether the paths
         specified in the config file exist."""
+
+        if path is None:
+            path = tum_esm_utils.files.rel_to_abs_path("../../config/config.json")
 
         with open(path, 'r') as f:
             return Config.model_validate_json(

--- a/src/types/config.py
+++ b/src/types/config.py
@@ -333,6 +333,7 @@ class Config(pydantic.BaseModel):
         if path is None:
             path = tum_esm_utils.files.rel_to_abs_path("../../config/config.json")
 
+        print("config", path)
         with open(path, 'r') as f:
             return Config.model_validate_json(
                 f.read(),

--- a/src/utils/files.py
+++ b/src/utils/files.py
@@ -1,6 +1,8 @@
-from typing import Optional
+from pathlib import PosixPath
+from typing import Optional, Union
 import os
 import re
+import yaml
 
 
 def list_directory(
@@ -25,3 +27,10 @@ def list_directory(
         ]
 
     return files
+
+
+def read_yaml(
+        file_path: Union[str, PosixPath]
+) -> dict[str, str]:
+    with open(file_path, 'r') as f:
+        return dict(yaml.load(f, Loader=yaml.FullLoader))

--- a/src/utils/metadata.py
+++ b/src/utils/metadata.py
@@ -1,9 +1,24 @@
-from typing import Optional
+from pathlib import PosixPath
+from typing import Optional, Union
 import os
+import yaml
 import em27_metadata
 import tum_esm_utils
 
-CONFIG_DIR = tum_esm_utils.files.rel_to_abs_path("../../config")
+
+def read_yaml(
+        file_path: Union[str, PosixPath]
+) -> dict[str, str]:
+    with open(file_path, 'r') as f:
+        return dict(yaml.load(f, Loader=yaml.FullLoader))
+
+
+config_setup = read_yaml(tum_esm_utils.files.rel_to_abs_path("../../config_setup.yml"))
+if config_setup['alternate_config_dir'] is None:
+    CONFIG_DIR = tum_esm_utils.files.rel_to_abs_path("../../config")
+else:
+    CONFIG_DIR = config_setup['alternate_config_dir']
+print("CONFIG DIR: ", CONFIG_DIR)
 
 
 def load_local_em27_metadata_interface(

--- a/tests/integration/test_config.py
+++ b/tests/integration/test_config.py
@@ -1,8 +1,15 @@
 import pytest
+import os
+import tum_esm_utils
+from src.utils.files import read_yaml
 import src
-
 
 @pytest.mark.order(2)
 @pytest.mark.integration
 def test_config() -> None:
-    src.types.Config.load()
+    config_setup = read_yaml(tum_esm_utils.files.rel_to_abs_path("../../config_setup.yml"))
+    if config_setup['alternate_config_dir'] is None:
+        config_path = None # default config path
+    else:
+        config_path = os.path.join(config_setup["alternate_config_dir"], "config.json")
+    src.types.Config.load(config_path)

--- a/tests/integration/test_metadata_connection.py
+++ b/tests/integration/test_metadata_connection.py
@@ -1,12 +1,20 @@
 import pytest
+import os
 import em27_metadata
+import tum_esm_utils
+from src.utils.files import read_yaml
 import src
 
 
 @pytest.mark.order(3)
 @pytest.mark.integration
 def test_metadata_connection() -> None:
-    config = src.types.Config.load()
+    config_setup = read_yaml(tum_esm_utils.files.rel_to_abs_path("../../config_setup.yml"))
+    if config_setup['alternate_config_dir'] is None:
+        config_path = None # default config path
+    else:
+        config_path = os.path.join(config_setup["alternate_config_dir"], "config.json")
+    config = src.types.Config.load(config_path)
     if config.general.metadata is None:
         pytest.skip("Remote metadata not configured")
     else:

--- a/tests/integration/test_profiles_connection.py
+++ b/tests/integration/test_profiles_connection.py
@@ -1,13 +1,21 @@
 import pytest
 import ftplib
+import os
 import warnings
+import tum_esm_utils
+from src.utils.files import read_yaml
 import src
 
 
 @pytest.mark.order(3)
 @pytest.mark.integration
 def test_profiles_connection() -> None:
-    config = src.types.Config.load()
+    config_setup = read_yaml(tum_esm_utils.files.rel_to_abs_path("../../config_setup.yml"))
+    if config_setup['alternate_config_dir'] is None:
+        config_path = None # default config path
+    else:
+        config_path = os.path.join(config_setup["alternate_config_dir"], "config.json")
+    config = src.types.Config.load(config_path)
     if config.profiles is None:
         return
     with ftplib.FTP(

--- a/tests/repository/test_local_metadata.py
+++ b/tests/repository/test_local_metadata.py
@@ -3,8 +3,16 @@ import os
 import pytest
 import tum_esm_utils
 import src
+from src.utils.files import read_yaml
 
-CONFIG_DIR = tum_esm_utils.files.rel_to_abs_path("../../config")
+
+config_setup = read_yaml(tum_esm_utils.files.rel_to_abs_path("../../config_setup.yml"))
+if config_setup['alternate_config_dir'] is None:
+    CONFIG_DIR = tum_esm_utils.files.rel_to_abs_path("../../config")
+else:
+    CONFIG_DIR = config_setup['alternate_config_dir']
+print("CONFIG DIR: ", CONFIG_DIR)
+
 LOCATIONS_PATH = os.path.join(CONFIG_DIR, "locations.json")
 SENSORS_PATH = os.path.join(CONFIG_DIR, "sensors.json")
 CAMPAIGNS_PATH = os.path.join(CONFIG_DIR, "campaigns.json")


### PR DESCRIPTION
WIP!

Closes #108

Based on v1.3.2 due to problems running retrievals on v1.4.0 (see #107).

 Config directory is specified in config_setup.yml.

Includes cherry pick of [Use sys.executable instead of .venv/bin/python to run retrievals](https://github.com/tum-esm/em27-retrieval-pipeline/commit/0af30503f1826da5c0add8acfb29b0e7233cc347)